### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile.mole2
+++ b/Dockerfile.mole2
@@ -12,14 +12,16 @@ COPY AppsAndServices/Queries/WebChemistry.Queries.Core/ ./AppsAndServices/Querie
 COPY AppsAndServices/Tunnels/WebChemistry.Tunnels.Core/ ./AppsAndServices/Tunnels/WebChemistry.Tunnels.Core/
 COPY AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/ ./AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/
 
-RUN while read -r project; do \
-      upgrade-assistant upgrade --non-interactive -f net10.0 -o Inplace "$project"; \
-    done << 'EOF'
+RUN <<EOF_RUN
+while read -r project; do
+  upgrade-assistant upgrade --non-interactive -f net10.0 -o Inplace "$project";
+done <<"EOF"
 ./Framework/Net/WebChemistry.Framework.Core/WebChemistry.Framework.Core.csproj
 ./AppsAndServices/Queries/WebChemistry.Queries.Core/WebChemistry.Queries.Core.csproj
 ./AppsAndServices/Tunnels/WebChemistry.Tunnels.Core/WebChemistry.Tunnels.Core.csproj
 ./AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/WebChemistry.Tunnels.Server.csproj
 EOF
+EOF_RUN
 
 RUN dotnet publish AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/WebChemistry.Tunnels.Server.csproj \
     -c Release \

--- a/Dockerfile.mole2
+++ b/Dockerfile.mole2
@@ -37,4 +37,4 @@ RUN chown -R app:app /app
 
 USER app
 
-ENTRYPOINT ["./mole2"]
+ENTRYPOINT ["/app/mole2"]

--- a/Dockerfile.mole2
+++ b/Dockerfile.mole2
@@ -12,16 +12,11 @@ COPY AppsAndServices/Queries/WebChemistry.Queries.Core/ ./AppsAndServices/Querie
 COPY AppsAndServices/Tunnels/WebChemistry.Tunnels.Core/ ./AppsAndServices/Tunnels/WebChemistry.Tunnels.Core/
 COPY AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/ ./AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/
 
-RUN <<EOF_RUN
-while read -r project; do
-  upgrade-assistant upgrade --non-interactive -f net10.0 -o Inplace "$project";
-done <<"EOF"
-./Framework/Net/WebChemistry.Framework.Core/WebChemistry.Framework.Core.csproj
-./AppsAndServices/Queries/WebChemistry.Queries.Core/WebChemistry.Queries.Core.csproj
-./AppsAndServices/Tunnels/WebChemistry.Tunnels.Core/WebChemistry.Tunnels.Core.csproj
-./AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/WebChemistry.Tunnels.Server.csproj
-EOF
-EOF_RUN
+RUN cmd='upgrade-assistant upgrade --non-interactive -f net10.0 -o Inplace' \
+&& $cmd ./Framework/Net/WebChemistry.Framework.Core/WebChemistry.Framework.Core.csproj \
+&& $cmd ./AppsAndServices/Queries/WebChemistry.Queries.Core/WebChemistry.Queries.Core.csproj \
+&& $cmd ./AppsAndServices/Tunnels/WebChemistry.Tunnels.Core/WebChemistry.Tunnels.Core.csproj \
+&& $cmd ./AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/WebChemistry.Tunnels.Server.csproj
 
 RUN dotnet publish AppsAndServices/Tunnels/WebChemistry.Tunnels.Server/WebChemistry.Tunnels.Server.csproj \
     -c Release \


### PR DESCRIPTION
Looks like some versions of Docker struggle with the HEREDOC syntax... I found this fix here https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/ and it seems to do the trick.

PS: I also set the entrypoint to the absolute path because [Singularity](https://github.com/sylabs/singularity) behaves slightly differently than Docker and one needs to do `singularity run -cwd /app ...` if the entrypoint is set to a relative path. I don't think there's any benefit to having a relative path in the entrypoint, so I made this extra change here.